### PR TITLE
Trim shell prefix

### DIFF
--- a/suggest/api.go
+++ b/suggest/api.go
@@ -17,7 +17,7 @@ const (
 	Creative        = "creative"
 )
 
-var ShellPrefix = []string{"$ ", "❯ "}
+var ShellPrefix = []string{"$", "❯"}
 
 func (s *Suggest) getParametersFor(preference string) map[string]interface{} {
 	switch preference {
@@ -58,20 +58,29 @@ func (s *Suggest) extractCommandsFromResponse(response string) []string {
 
 	var codeSnippets []string
 	for _, match := range matches {
-		if len(match) != 3 {
-			continue
+		if len(match) == 3 {
+			codeSnippets = append(codeSnippets, s.refineCommand(match[2]))
 		}
-		codeSnippet := match[2]
-		for _, prefix := range ShellPrefix {
-			if strings.HasPrefix(codeSnippet, prefix) {
-				codeSnippet = strings.TrimPrefix(codeSnippet, prefix)
-				break
-			}
-		}
-		codeSnippets = append(codeSnippets, codeSnippet)
 	}
 
 	return codeSnippets
+}
+
+func (s *Suggest) refineCommand(command string) string {
+	result := strings.Clone(command)
+
+	// Trim shell prefixes
+	for _, prefix := range ShellPrefix {
+		if strings.HasPrefix(result, prefix) {
+			result = strings.TrimPrefix(result, prefix)
+			break
+		}
+	}
+
+	// Trim leading and trailing whitespaces
+	result = strings.TrimSpace(result)
+
+	return result
 }
 
 func (s *Suggest) getCommandSuggestionFor(mode, term string, prompt string) (string, error) {

--- a/suggest/api.go
+++ b/suggest/api.go
@@ -3,11 +3,12 @@ package suggest
 import (
 	"context"
 	"fmt"
-	ollama "github.com/jmorganca/ollama/api"
-	"github.com/yusufcanb/tlm/shell"
 	"regexp"
 	"runtime"
 	"strings"
+
+	ollama "github.com/jmorganca/ollama/api"
+	"github.com/yusufcanb/tlm/shell"
 )
 
 const (
@@ -15,6 +16,8 @@ const (
 	Balanced        = "balanced"
 	Creative        = "creative"
 )
+
+var ShellPrefix = []string{"$ ", "❯ "}
 
 func (s *Suggest) getParametersFor(preference string) map[string]interface{} {
 	switch preference {
@@ -55,9 +58,17 @@ func (s *Suggest) extractCommandsFromResponse(response string) []string {
 
 	var codeSnippets []string
 	for _, match := range matches {
-		if len(match) == 3 {
-			codeSnippets = append(codeSnippets, match[2])
+		if len(match) != 3 {
+			continue
 		}
+		codeSnippet := match[2]
+		for _, prefix := range ShellPrefix {
+			if strings.HasPrefix(codeSnippet, prefix) {
+				codeSnippet = strings.TrimPrefix(codeSnippet, prefix)
+				break
+			}
+		}
+		codeSnippets = append(codeSnippets, codeSnippet)
 	}
 
 	return codeSnippets

--- a/suggest/api_test.go
+++ b/suggest/api_test.go
@@ -1,0 +1,32 @@
+package suggest
+
+import (
+	"testing"
+
+	ollama "github.com/jmorganca/ollama/api"
+	"github.com/yusufcanb/tlm/config"
+)
+
+func TestRefineCommand(t *testing.T) {
+	con := config.New()
+	con.LoadOrCreateConfig()
+
+	o, _ := ollama.ClientFromEnvironment()
+	s := New(o)
+
+	if s.refineCommand("ls -al") != "ls -al" {
+		t.Error("no change should be made if the command is already okay")
+	}
+
+	if s.refineCommand("$ ls -al") != "ls -al" {
+		t.Error("shell prefix should be removed")
+	}
+
+	if s.refineCommand("❯ ls -al") != "ls -al" {
+		t.Error("shell prefix should be removed")
+	}
+
+	if s.refineCommand(" ls -al") != "ls -al" {
+		t.Error("leading space should be removed")
+	}
+}


### PR DESCRIPTION
Hi, thank you for building and publishing this fascinating cli app.
I had a tiny issue with `suggest` command. llama puts a shell prefix such as `$` or `❯` sometimes, like below.

```sh
❯ tlm s 'create secret'
┃ > Thinking... (3.875119084s)
┃ > $ openssl rand -base64 32
┃ > Executing...

bash: $: command not found
```

It's not very often but it's disrupting the experience since you can't execute the command right after the suggestion when it happens.

I made a small solution simply by trimming the shell prefix if exists. I think it can be more developed like adding below method.
```go
func (s *Suggest) refineCommand(command string) string {
  // refine the generated command, such as trimming shell prefix or removing possible mistakes
}
```
Because the generated commands are not always perfect, it would be helpful to handle known/possible issues.