### PR TITLE
fix: prevent config form select crash on invalid saved values

### DIFF
--- a/pkg/config/form.go
+++ b/pkg/config/form.go
@@ -18,6 +18,36 @@ type ConfigForm struct {
 	suggest string
 }
 
+func normalizeConfigFormValues(modelNames []string, model, shellValue, suggest, explain string) (string, string, string, string) {
+	if len(modelNames) > 0 && !contains(modelNames, model) {
+		model = modelNames[0]
+	}
+
+	validShells := []string{"auto", "powershell", "bash", "zsh"}
+	if !contains(validShells, shellValue) {
+		shellValue = defaultShell
+	}
+
+	validStyles := []string{Stable, Balanced, Creative}
+	if !contains(validStyles, suggest) {
+		suggest = defaultSuggestionPolicy
+	}
+	if !contains(validStyles, explain) {
+		explain = defaultExplainPolicy
+	}
+
+	return model, shellValue, suggest, explain
+}
+
+func contains(values []string, value string) bool {
+	for _, candidate := range values {
+		if candidate == value {
+			return true
+		}
+	}
+	return false
+}
+
 func (c *ConfigForm) Run(api *ollama.Client) error {
 
 	// get available models from Ollama
@@ -27,11 +57,29 @@ func (c *ConfigForm) Run(api *ollama.Client) error {
 		return err
 	}
 
-	// create model options from available Ollama models
-	modelOptions := make([]huh.Option[string], 0, len(models.Models))
+	if len(models.Models) == 0 {
+		return fmt.Errorf("no Ollama models found. Run `ollama pull <model_name>` first")
+	}
+
 	sort.Slice(models.Models, func(i, j int) bool {
 		return models.Models[i].Name < models.Models[j].Name
 	})
+
+	modelNames := make([]string, 0, len(models.Models))
+	for _, model := range models.Models {
+		modelNames = append(modelNames, model.Name)
+	}
+
+	c.model, c.shell, c.suggest, c.explain = normalizeConfigFormValues(
+		modelNames,
+		c.model,
+		c.shell,
+		c.suggest,
+		c.explain,
+	)
+
+	// create model options from available Ollama models
+	modelOptions := make([]huh.Option[string], 0, len(models.Models))
 	for _, model := range models.Models {
 		modelOptions = append(modelOptions, huh.NewOption(
 			fmt.Sprintf("%s (%.2f GB)", model.Name, float64(model.Size)/(1024*1024*1024)),

--- a/pkg/config/form_test.go
+++ b/pkg/config/form_test.go
@@ -1,0 +1,40 @@
+package config
+
+import "testing"
+
+func TestNormalizeConfigFormValuesFallsBackToValidDefaults(t *testing.T) {
+	model, shell, suggest, explain := normalizeConfigFormValues(
+		[]string{"llama3", "qwen2.5"},
+		"missing-model",
+		"fish",
+		"",
+		"experimental",
+	)
+
+	if model != "llama3" {
+		t.Fatalf("expected first available model fallback, got %q", model)
+	}
+	if shell != defaultShell {
+		t.Fatalf("expected default shell fallback, got %q", shell)
+	}
+	if suggest != defaultSuggestionPolicy {
+		t.Fatalf("expected default suggestion policy fallback, got %q", suggest)
+	}
+	if explain != defaultExplainPolicy {
+		t.Fatalf("expected default explain policy fallback, got %q", explain)
+	}
+}
+
+func TestNormalizeConfigFormValuesKeepsValidSelections(t *testing.T) {
+	model, shell, suggest, explain := normalizeConfigFormValues(
+		[]string{"llama3", "qwen2.5"},
+		"qwen2.5",
+		"zsh",
+		Creative,
+		Stable,
+	)
+
+	if model != "qwen2.5" || shell != "zsh" || suggest != Creative || explain != Stable {
+		t.Fatalf("expected values to remain unchanged, got model=%q shell=%q suggest=%q explain=%q", model, shell, suggest, explain)
+	}
+}


### PR DESCRIPTION
Fixes #41

The config form can start with saved values that are no longer valid (for example a model that is not installed anymore). In that state the select field starts with an invalid index and panics on key handling. This normalizes model/shell/style values to valid defaults before rendering and returns a clear error when no Ollama models are available.

Greetings, saschabuehrle